### PR TITLE
Add: support for custom image styling

### DIFF
--- a/src/EasyZoomOnHover.tsx
+++ b/src/EasyZoomOnHover.tsx
@@ -36,6 +36,7 @@ export type EasyZoomOnHoverProps = {
     zoomContainerWidth?: number;
     zoomContainerHeight?: number;
     zoomLensScale?: number;
+    style?: React.CSSProperties;
 }
 
 export type ImageDimensionType = {
@@ -46,7 +47,7 @@ export type ImageDimensionType = {
 
 const EasyZoomOnHover = React.forwardRef(function EasyZoomOnHover(props: EasyZoomOnHoverProps, ref: React.Ref<HTMLDivElement>) {
 
-    const { mainImage, zoomImage, loadingIndicator, delayTimer, distance = 10, zoomContainerWidth } = props;
+    const { mainImage, zoomImage, loadingIndicator, delayTimer, distance = 10, zoomContainerWidth, style } = props;
     const { createZoomImage: createZoomImageHover } = useZoomImageHover();
 
     const imageHoverContainerRef = React.useRef<HTMLDivElement>(null);
@@ -109,7 +110,7 @@ const EasyZoomOnHover = React.forwardRef(function EasyZoomOnHover(props: EasyZoo
                     className="EasyZoomHoverSmallImage"
                     onLoad={handleImageLoad}
                     ref={imgRef}
-                    style={{ height: "auto", width: "auto" }}
+                    style={{ height: "auto", width: "auto", ...style }}
                     alt={mainImage.alt ?? "Small Pic"}
                     src={mainImage.src}
                 />

--- a/src/EasyZoomOnMove.tsx
+++ b/src/EasyZoomOnMove.tsx
@@ -21,6 +21,7 @@ type EasyZoomOnMovePropsType = {
         src: string;
         alt?: string;
     };
+    style?: React.CSSProperties;
 
 }
 
@@ -32,7 +33,7 @@ type ImageDimensionType = {
 
 const EasyZoomOnMove = (props: EasyZoomOnMovePropsType) => {
 
-    const { mainImage, zoomImage, loadingIndicator, delayTimer } = props;
+    const { mainImage, zoomImage, loadingIndicator, delayTimer, style } = props;
     const [isImageLoaded, setIsImageLoaded] = React.useState(false);
     const { createZoomImage: createZoomImageMove } = useZoomImageMove();
     const imageMoveContainerRef = React.useRef<HTMLDivElement>(null)
@@ -86,7 +87,7 @@ const EasyZoomOnMove = (props: EasyZoomOnMovePropsType) => {
             >
                 <img className='EasyImageZoomOnMoveImage'
                     onLoad={handleImageLoad} ref={imgRef as React.RefObject<HTMLImageElement>}
-                    style={{ width: "full", height: "full" }}
+                    style={{ height: "auto", width: "auto", ...style }}
                     alt={mainImage.alt ?? "Large Pic"} src={mainImage.src} />
             </div>
 

--- a/src/stories/hooks/customStyling.stories.tsx
+++ b/src/stories/hooks/customStyling.stories.tsx
@@ -1,0 +1,145 @@
+import { StoryFn, Meta } from "@storybook/react";
+import * as React from "react";
+import EasyZoomOnHover from "../../EasyZoomOnHover";
+
+export default {
+    title: "Components/CustomStyling",
+    component: EasyZoomOnHover,
+    args: {
+    }
+} as Meta<typeof EasyZoomOnHover>;
+
+
+const Template: StoryFn<typeof EasyZoomOnHover> = (args) => <div>
+    <div >
+        <EasyZoomOnHover {...args}
+            mainImage={{
+                src: "https://m.media-amazon.com/images/I/71sgEIlSvfL._AC_SX466_.jpg",
+                alt: "My Product",
+                width:600,
+                height:600,
+            }}
+            zoomImage={{
+                src: "https://m.media-amazon.com/images/I/71sgEIlSvfL._AC_SX1500_.jpg",
+                alt: "My Product Zoom"
+            }}
+            style={{width:'100%',height:'100%'}}
+        />
+
+
+    </div>
+    <div style={{ marginTop: "30px" }}>
+        <h2 className="componentApi">Component Api: </h2>
+        <table style={{ textAlign: "center" }}>
+            <thead >
+                <tr >
+                    <th style={{ width: "200px", border: '1px solid gray', padding: '6px' }}>Prop</th>
+                    <th style={{ width: "200px", border: '1px solid gray' }}>Type</th>
+                    <th style={{ width: "200px", border: '1px solid gray' }}>Default</th>
+                    <th style={{ maxWidth: "400px", border: '1px solid gray' }}>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr >
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>mainImage</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>
+                        <pre style={{ backgroundColor: "#f1f5f9", textAlign: "start" }}>
+                            {
+                                `   
+    mainImage: {
+        width?: number;
+        height?: number;
+        src: string;
+        alt?: string;
+    }
+                            `
+                            }
+                        </pre>
+                    </td>
+                    <td style={{ border: "1px solid gray" }}>
+                        <pre style={{ backgroundColor: "#f1f5f9", textAlign: "start" }}>
+                            {
+                                `   
+        width: 500px;
+        height?: 500px;
+                            `
+                            }
+                        </pre>
+
+                    </td>
+                    <td style={{ border: "1px solid gray" }}>Main image that is displayed normally.</td>
+                </tr>
+                <tr >
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>zoomImage</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>
+                        <pre style={{ backgroundColor: "#f1f5f9", textAlign: "start" }}>
+                            {
+                                `   
+        zoomImage: {
+            src: string;
+            alt?: string;
+        }
+                            `
+                            }
+                        </pre>
+                    </td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>
+                        <pre style={{ backgroundColor: "#f1f5f9", textAlign: "start" }}>
+                            {
+                                `   
+    src: zoomImage.src ?? mainImage.src ;  
+    alt : zoomImage.alt ?? mainImage.alt;  
+                            `
+                            }
+                        </pre>
+
+                    </td>
+                    <td style={{ border: "1px solid gray" }}>Zoom Image that appears when user hovers on main image.</td>
+                </tr>
+                <tr>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>loadingIndicator</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>React.ReactNode</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}> <pre
+                        style={{ backgroundColor: "#f1f5f9", padding: "8px" }}>{"<EasySkeleton />"}</pre> </td>
+                    <td style={{ border: "1px solid gray" }}>Loading Widget before component loads properly.</td>
+                </tr>
+                <tr>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>distance</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>number</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>10</td>
+                    <td style={{ border: "1px solid gray" }}>distance between main image and zoomed Image.</td>
+                </tr>
+                <tr>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>delayTimer</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>number</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>1600</td>
+                    <td style={{ border: "1px solid gray" }}>How long loading indicator is shown</td>
+                </tr>
+                <tr>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>zoomContainerWidth</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>number</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>500</td>
+                    <td style={{ border: "1px solid gray" }}>Width of zoom image container.</td>
+                </tr>
+                <tr>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>zoomContainerHeight</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>number</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>500</td>
+                    <td style={{ border: "1px solid gray" }}>Height of zoom image container.</td>
+                </tr>
+                <tr>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>zoomLensScale</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>number</td>
+                    <td style={{ border: "1px solid gray", padding: "4px" }}>3</td>
+                    <td style={{ border: "1px solid gray" }}>Zoom lens scale.</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <br />
+    <br />
+    <br />
+</div>
+    ;
+
+export const ZoomImageOnHover = Template.bind({});


### PR DESCRIPTION
Currently, there is no option to customize the image tag generated by the `EasyZoomOn` Components. I have added the option to optionally ask for custom inline style property from the user so that they can be used to style the image however they seem fit.


Things I have done.

- Created an additional story which is copy of src/stories/hooks/EasyZoomOnHover.stories.tsx.
- Added a sample example on how custom styling on image works.
- Tested the same local package on my hobby site and ensured nothing is broken.
![image](https://github.com/user-attachments/assets/30288c02-43b7-4219-a1ca-9db89334f2aa)


Usecase:

Ecommerce product listing page where there is a carousel of images. The images are from a third party source with different width and height for each image.  We can set the width and height of the container, but can't use them to manipulate the underlying images. Example: I want the image to span the width of the entire parent.
       
Certain images are small and cause a white space 
![image](https://github.com/user-attachments/assets/04386e80-dcbf-493b-8140-50ff0e18f199)

By passing custom styling, I was able to fix the issue on my own.
```typescript
 <EasyZoomOnHover {...args}
            mainImage={{
                src: "https://m.media-amazon.com/images/I/71sgEIlSvfL._AC_SX466_.jpg",
                alt: "My Product",
                width:600,
                height:600,
            }}
            zoomImage={{
                src: "https://m.media-amazon.com/images/I/71sgEIlSvfL._AC_SX1500_.jpg",
                alt: "My Product Zoom"
            }}
            style={{width:'100%',height:'100%'}} // Accepts any valid CSS property
        />
``` 